### PR TITLE
added client-id and client-secret support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,11 @@
   </properties>
   <dependencies>
     <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20240303</version>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
       <version>${spring-boot.version}</version>

--- a/src/main/java/de/ukbonn/mwtek/dashboard/auth/RestConsumer.java
+++ b/src/main/java/de/ukbonn/mwtek/dashboard/auth/RestConsumer.java
@@ -19,9 +19,11 @@
 package de.ukbonn.mwtek.dashboard.auth;
 
 import de.ukbonn.mwtek.dashboard.configuration.AbstractRestConfiguration;
-import java.io.File;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
 import javax.net.ssl.SSLContext;
+import java.net.HttpURLConnection;
+import java.net.URL;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.HttpClients;
@@ -34,6 +36,7 @@ import org.springframework.util.ResourceUtils;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.HttpHeaders;
+import org.json.*;
 import java.util.Collections;
 
 
@@ -98,16 +101,59 @@ public class RestConsumer {
   }
 
   /**
-   * helper for REST calls without Auth
+   * helper for REST calls that use keycloak token authentication
    *
    * @return a pre configured spring RestTemplate object
    */
   protected RestTemplate getRestTemplateToken() {
+    String accessToken = "";
+
+    try {
+      String tokenUrl = restConfiguration.getTokenUrl();
+      String clientId = restConfiguration.getClientId();
+      String clientSecret = restConfiguration.getClientSecret();
+
+      // create post request to fetch access token
+      String body = "client_id=" + clientId + "&client_secret=" + clientSecret + "&grant_type=client_credentials";
+      URL url = new URL(tokenUrl);
+      HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+      connection.setRequestMethod("POST");
+      connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+      connection.setDoOutput(true);
+
+      // write the post body
+      try (OutputStream os = connection.getOutputStream()) {
+        byte[] input = body.getBytes(StandardCharsets.UTF_8);
+        os.write(input, 0, input.length);
+      }
+
+      // get response
+      try (BufferedReader br = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
+        StringBuilder response = new StringBuilder();
+        String line;
+        while ((line = br.readLine()) != null) {
+          response.append(line);
+        }
+
+        // extract access token from response
+        accessToken = new JSONObject(response.toString()).getString("access_token");
+
+      } catch (IOException e) {
+        log.error("Couldn't fetch access token due to: " + connection.getResponseMessage() +
+                " (Code: " + connection.getResponseCode() + ")");
+      }
+    } catch (Exception e) {
+      log.error("Couldn't fetch access token due to following exception: " + e.getMessage());
+    }
+
+    // build rest template
     RestTemplate result = new RestTemplateBuilder().build();
     result.getMessageConverters().add(0, new StringHttpMessageConverter(StandardCharsets.UTF_8));
 
+    // use interceptor to add fetched access token to request
+    String finalAccessToken = accessToken;
     ClientHttpRequestInterceptor bearerTokenInterceptor = (request, body, execution) -> {
-      request.getHeaders().set(HttpHeaders.AUTHORIZATION, "Bearer " + restConfiguration.getRestPassword());
+      request.getHeaders().set(HttpHeaders.AUTHORIZATION, "Bearer " + finalAccessToken);
       return execution.execute(request, body);
     };
 

--- a/src/main/java/de/ukbonn/mwtek/dashboard/configuration/AbstractRestConfiguration.java
+++ b/src/main/java/de/ukbonn/mwtek/dashboard/configuration/AbstractRestConfiguration.java
@@ -44,6 +44,22 @@ public abstract class AbstractRestConfiguration {
   private String restUrl;
 
   /**
+   * The full url (including hostname, port and realm) to the token generate url of the keycloak server.
+   */
+  private String tokenUrl;
+
+  /**
+   * The client id, which is configured in keycloak for the fhir server. Used to generate the access token.
+   */
+  private String clientId;
+
+  /**
+   * The client secret, which is configured in keycloak for the fhir server. Used to generate the access token.
+   */
+  private String clientSecret;
+
+
+  /**
    * The username used when basic authentication (default method) is selected.
    */
   private String restUser;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -35,11 +35,15 @@ global:
   generate-ukb-renal-replacement-model-data: false
 fhir:
   server:
-    ## The authentication method, one of NONE, SSL, TOKEN or BASIC (default)
+    ## The authentication method, one of NONE, SSL, BASIC or TOKEN (default)
     auth-method: TOKEN
     ## the base url of the fhir server (needs to end with a "/")
     rest-url: http://127.0.0.1/fhir/
-    ## BASIC (or 'rest-password' as TOKEN)
+    ## TOKEN (Keycloak)
+    token-url: https://<keycloak-server>/realms/<realm-name>/protocol/openid-connect/token
+    client-id: x
+    client-secret: y
+    ## BASIC
     rest-user: x
     rest-password: y
     ## SSL


### PR DESCRIPTION
For integration of keycloak as authentication method. It's possible to `application.yaml` configure a keycloak server, keycloak client-id and keycloak-secret now. The token is then fetched automatically for the request, using the configured client-id and client-secret.